### PR TITLE
feat: 유저 프로필 이미지 수정시 이전 이미지 삭제

### DIFF
--- a/src/main/java/com/caro/bizkit/domain/user/service/UserService.java
+++ b/src/main/java/com/caro/bizkit/domain/user/service/UserService.java
@@ -58,8 +58,14 @@ public class UserService {
     public UserResponse updateMyStatus(UserPrincipal principal, UserRequest request) {
         User user = userRepository.findById(principal.id())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "User not found"));
+        String previousKey = user.getProfileImageKey();
         if (request != null) {
             applyUpdates(user, request);
+            if (previousKey != null
+                    && request.profile_image_key() != null
+                    && !previousKey.equals(request.profile_image_key())) {
+                s3Service.deleteObject(previousKey);
+            }
         }
         return toResponse(user);
     }


### PR DESCRIPTION

**Title**
feat: 이전 프로필 이미지 삭제

**Body**
#### 요약
- 프로필 수정시 새 key를 받으면 이전 key의 객체를 삭제함



Release: v0.6.7

