### PR TITLE
fix: 로그인, refresh, error, callback이 filter를 안타게 조정

### DIFF
--- a/src/main/java/com/caro/bizkit/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/caro/bizkit/security/JwtAuthenticationFilter.java
@@ -43,6 +43,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return  path.startsWith("/api/auth/login") ||
+                path.equals("/api/auth/rotation") ||
+                path.equals("/api/auth/kakao/callback") ||
+                path.equals("/error");
+    }
+
+    @Override
     protected void doFilterInternal(
             HttpServletRequest request,
             HttpServletResponse response,


### PR DESCRIPTION

**Title**
fix: 로그인, refresh, error  api가 filter를 안타게 조정

**Body**
#### 요약
- 만료된 쿠키가 남아있을때 필터때문에 api에 접근하지 못하는 문제 발생
- 로그인, 재발행, 잘못된 api일 경우에는 필터를 타지 않게 설정
