### PR TITLE
feat(chat): 채팅 상대 프로필 조회 API 추가

### DIFF
--- a/src/main/java/com/caro/bizkit/domain/chat/controller/ChatUserController.java
+++ b/src/main/java/com/caro/bizkit/domain/chat/controller/ChatUserController.java
@@ -1,0 +1,34 @@
+package com.caro.bizkit.domain.chat.controller;
+
+import com.caro.bizkit.common.ApiResponse.ApiResponse;
+import com.caro.bizkit.domain.chat.dto.ChatPartnerProfileResponse;
+import com.caro.bizkit.domain.chat.service.ChatRoomService;
+import com.caro.bizkit.domain.user.dto.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/chat/users")
+@RequiredArgsConstructor
+@Tag(name = "Chat User", description = "채팅 유저 API")
+public class ChatUserController {
+
+    private final ChatRoomService chatRoomService;
+
+    @GetMapping("/{user_id}")
+    @Operation(summary = "채팅 상대 프로필 조회", description = "공통 채팅방이 있는 상대의 프로필을 조회합니다.")
+    public ResponseEntity<ApiResponse<ChatPartnerProfileResponse>> getPartnerProfile(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("user_id") Integer userId
+    ) {
+        ChatPartnerProfileResponse response = chatRoomService.getPartnerProfile(principal, userId);
+        return ResponseEntity.ok(ApiResponse.success("사용자 정보 조회 성공", response));
+    }
+}

--- a/src/main/java/com/caro/bizkit/domain/chat/dto/ChatPartnerProfileResponse.java
+++ b/src/main/java/com/caro/bizkit/domain/chat/dto/ChatPartnerProfileResponse.java
@@ -1,0 +1,25 @@
+package com.caro.bizkit.domain.chat.dto;
+
+import com.caro.bizkit.domain.user.entity.User;
+
+public record ChatPartnerProfileResponse(
+        Integer id,
+        String name,
+        String company,
+        String department,
+        String position,
+        String profile_image_url,
+        String description
+) {
+    public static ChatPartnerProfileResponse from(User user, String profileImageUrl) {
+        return new ChatPartnerProfileResponse(
+                user.getId(),
+                user.getName(),
+                user.getCompany(),
+                user.getDepartment(),
+                user.getPosition(),
+                profileImageUrl,
+                user.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/caro/bizkit/domain/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/caro/bizkit/domain/chat/repository/ChatParticipantRepository.java
@@ -24,6 +24,14 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
     Optional<ChatParticipant> findCommonRoomParticipant(@Param("userId1") Integer userId1,
                                                         @Param("userId2") Integer userId2);
 
+    @Query("SELECT CASE WHEN EXISTS (" +
+            "SELECT cp1 FROM ChatParticipant cp1 " +
+            "JOIN ChatParticipant cp2 ON cp1.chatRoom.id = cp2.chatRoom.id " +
+            "WHERE cp1.user.id = :userId1 AND cp1.leftAt IS NULL " +
+            "AND cp2.user.id = :userId2 AND cp2.leftAt IS NULL" +
+            ") THEN true ELSE false END")
+    boolean existsSharedActiveRoom(@Param("userId1") Integer userId1, @Param("userId2") Integer userId2);
+
     @Query("SELECT cp FROM ChatParticipant cp " +
             "JOIN FETCH cp.chatRoom " +
             "WHERE cp.user.id = :userId AND cp.leftAt IS NULL " +

--- a/src/main/java/com/caro/bizkit/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/caro/bizkit/domain/chat/service/ChatRoomService.java
@@ -1,5 +1,8 @@
 package com.caro.bizkit.domain.chat.service;
 
+import com.caro.bizkit.common.S3.service.S3Service;
+import com.caro.bizkit.common.exception.CustomException;
+import com.caro.bizkit.domain.chat.dto.ChatPartnerProfileResponse;
 import com.caro.bizkit.domain.chat.dto.ChatRoomCreateRequest;
 import com.caro.bizkit.domain.chat.dto.ChatRoomListResult;
 import com.caro.bizkit.domain.chat.dto.ChatRoomResponse;
@@ -25,6 +28,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
@@ -38,6 +42,7 @@ public class ChatRoomService {
     private final CardRepository cardRepository;
     private final UserRepository userRepository;
     private final StringRedisTemplate redisTemplate;
+    private final S3Service s3Service;
 
     private static final String ROOM_LOCK_PREFIX = "chat:room:lock:";
     private static final Duration LOCK_TTL = Duration.ofSeconds(5);
@@ -176,6 +181,28 @@ public class ChatRoomService {
         }
 
         participant.leave();
+    }
+
+    @Transactional(readOnly = true)
+    public ChatPartnerProfileResponse getPartnerProfile(UserPrincipal principal, Integer targetUserId) {
+        Integer myId = principal.id();
+
+        if (myId.equals(targetUserId)) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "자기 자신의 프로필은 조회할 수 없습니다");
+        }
+
+        User targetUser = userRepository.findByIdAndDeletedAtIsNull(targetUserId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"));
+
+        if (!chatParticipantRepository.existsSharedActiveRoom(myId, targetUserId)) {
+            throw new CustomException(HttpStatus.FORBIDDEN, "채팅 상대의 프로필을 조회할 권한이 없습니다");
+        }
+
+        String profileImageUrl = StringUtils.hasText(targetUser.getProfileImageKey())
+                ? s3Service.getPublicUrl(targetUser.getProfileImageKey())
+                : null;
+
+        return ChatPartnerProfileResponse.from(targetUser, profileImageUrl);
     }
 
     private List<ChatParticipant> findMyParticipants(Integer userId, Integer cursorId, int limit) {


### PR DESCRIPTION

**Title**
feat(chat): 채팅 상대 프로필 조회 API 추가

**Body**
- 채팅중인 상대방의 프로필(최신 명함) 조회 api
- 자기 자신은 조회할수 없으며, 채팅 중이 아닌 사용자 또한 조회 할수 없다.

close #154 