### PR TITLE
fix: 조회 size 제한(max: 30), use index 추가

### DIFF
--- a/src/main/java/com/caro/bizkit/domain/card/controller/WalletController.java
+++ b/src/main/java/com/caro/bizkit/domain/card/controller/WalletController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -98,7 +99,7 @@ public class WalletController {
     })
     public ResponseEntity<ApiResponse<List<WalletResponse>>> getCollectedCards(
             @AuthenticationPrincipal UserPrincipal user,
-            @RequestParam(defaultValue = "20") Integer size,
+            @RequestParam(defaultValue = "20") @Max(value = 30, message = "size는 최대 30까지 허용됩니다") Integer size,
             @RequestParam(required = false) Integer cursorId,
             @RequestParam(required = false) @Size(max = 100, message = "검색어는 100자 이하로 입력해주세요") String keyword
     ) {

--- a/src/main/java/com/caro/bizkit/domain/card/repository/UserCardRepository.java
+++ b/src/main/java/com/caro/bizkit/domain/card/repository/UserCardRepository.java
@@ -17,7 +17,7 @@ public interface UserCardRepository extends JpaRepository<UserCard, Integer> {
 
     @Query(value = """
             SELECT uc.*
-            FROM user_card uc
+            FROM user_card uc  USE INDEX (idx_user_card_user_id_id)
             JOIN card c ON c.id = uc.card_id
             WHERE uc.user_id = :userId
               AND (
@@ -29,7 +29,7 @@ public interface UserCardRepository extends JpaRepository<UserCard, Integer> {
                OR c.department LIKE CONCAT('%', :keyword, '%')
               )
             ORDER BY uc.id DESC
-            """, nativeQuery = true)
+""", nativeQuery = true)
     List<UserCard> searchCollectedCards(
             @Param("userId") Integer userId,
             @Param("keyword") String keyword,
@@ -38,7 +38,7 @@ public interface UserCardRepository extends JpaRepository<UserCard, Integer> {
 
     @Query(value = """
             SELECT uc.*
-            FROM user_card uc
+            FROM user_card uc  USE INDEX (idx_user_card_user_id_id)
             JOIN card c ON c.id = uc.card_id
             WHERE uc.user_id = :userId
               AND uc.id < :cursorId
@@ -51,7 +51,7 @@ public interface UserCardRepository extends JpaRepository<UserCard, Integer> {
                OR c.department LIKE CONCAT('%', :keyword, '%')
               )
             ORDER BY uc.id DESC
-            """, nativeQuery = true)
+""", nativeQuery = true)
     List<UserCard> searchCollectedCardsWithCursor(
             @Param("userId") Integer userId,
             @Param("cursorId") Integer cursorId,


### PR DESCRIPTION
### 기능 추가 + ReleaseID + 이슈 종료
**Title**
fix: 조회 size 제한(max: 30), use index 추가

**Body**
#### 요약
- 요청당 가져오는 명함수 최대 30으로 설정
- index를 강제해서 DB에서 sorting부분을 완화

