### PR TITLE
refactor: 검색 api n+1 문제 개선

### DIFF
--- a/src/main/java/com/caro/bizkit/domain/card/repository/UserCardRepository.java
+++ b/src/main/java/com/caro/bizkit/domain/card/repository/UserCardRepository.java
@@ -16,8 +16,8 @@ public interface UserCardRepository extends JpaRepository<UserCard, Integer> {
     List<UserCard> findByUserIdAndIdLessThanOrderByIdDesc(Integer userId, Integer cursorId, Pageable pageable);
 
     @Query(value = """
-            SELECT uc.*
-            FROM user_card uc  USE INDEX (idx_user_card_user_id_id)
+            SELECT uc.id
+            FROM user_card uc USE INDEX (idx_user_card_user_id_id)
             JOIN card c ON c.id = uc.card_id
             WHERE uc.user_id = :userId
               AND (
@@ -29,16 +29,16 @@ public interface UserCardRepository extends JpaRepository<UserCard, Integer> {
                OR c.department LIKE CONCAT('%', :keyword, '%')
               )
             ORDER BY uc.id DESC
-""", nativeQuery = true)
-    List<UserCard> searchCollectedCards(
+            """, nativeQuery = true)
+    List<Integer> searchCollectedCardIds(
             @Param("userId") Integer userId,
             @Param("keyword") String keyword,
             Pageable pageable
     );
 
     @Query(value = """
-            SELECT uc.*
-            FROM user_card uc  USE INDEX (idx_user_card_user_id_id)
+            SELECT uc.id
+            FROM user_card uc USE INDEX (idx_user_card_user_id_id)
             JOIN card c ON c.id = uc.card_id
             WHERE uc.user_id = :userId
               AND uc.id < :cursorId
@@ -51,13 +51,22 @@ public interface UserCardRepository extends JpaRepository<UserCard, Integer> {
                OR c.department LIKE CONCAT('%', :keyword, '%')
               )
             ORDER BY uc.id DESC
-""", nativeQuery = true)
-    List<UserCard> searchCollectedCardsWithCursor(
+            """, nativeQuery = true)
+    List<Integer> searchCollectedCardIdsWithCursor(
             @Param("userId") Integer userId,
             @Param("cursorId") Integer cursorId,
             @Param("keyword") String keyword,
             Pageable pageable
     );
+
+    @Query("""
+            SELECT uc FROM UserCard uc
+            JOIN FETCH uc.card c
+            LEFT JOIN FETCH c.user
+            WHERE uc.id IN :ids
+            ORDER BY uc.id DESC
+            """)
+    List<UserCard> findAllByIdInWithFetch(@Param("ids") List<Integer> ids);
 
     void deleteAllByUserId(Integer userId);
 

--- a/src/main/java/com/caro/bizkit/domain/card/service/WalletService.java
+++ b/src/main/java/com/caro/bizkit/domain/card/service/WalletService.java
@@ -135,12 +135,13 @@ public class WalletService {
             String escaped = keyword.replace("\\", "\\\\")
                                     .replace("%", "\\%")
                                     .replace("_", "\\_");
-            if (cursorId == null) {
-                return userCardRepository.searchCollectedCards(
-                        userId, escaped, PageRequest.of(0, limit));
+            List<Integer> ids = cursorId == null
+                    ? userCardRepository.searchCollectedCardIds(userId, escaped, PageRequest.of(0, limit))
+                    : userCardRepository.searchCollectedCardIdsWithCursor(userId, cursorId, escaped, PageRequest.of(0, limit));
+            if (ids.isEmpty()) {
+                return List.of();
             }
-            return userCardRepository.searchCollectedCardsWithCursor(
-                    userId, cursorId, escaped, PageRequest.of(0, limit));
+            return userCardRepository.findAllByIdInWithFetch(ids);
         }
         if (cursorId == null) {
             return userCardRepository.findByUserIdOrderByIdDesc(userId, PageRequest.of(0, limit));


### PR DESCRIPTION
**Title**
refactor: 검색 api n+1 문제 개선

**Body**
#### 요약
- 1개의 요청에 대해 size=20기준 최대 41번의 쿼리 포착
- 2단계 쿼리 실행 후 41->2 개선