### PR TITLE
refactor: Redis 동적 구독을 고정 채널로 전환 및 edge case 처리 추가

### DIFF
--- a/src/main/java/com/caro/bizkit/domain/ai/service/AiCardGenerationService.java
+++ b/src/main/java/com/caro/bizkit/domain/ai/service/AiCardGenerationService.java
@@ -80,9 +80,7 @@ public class AiCardGenerationService {
             submitResponse = aiClient.submitCardGeneration(requestRef[0]);
         } catch (Exception e) {
             log.error("User {} AI 명함 생성 요청 실패: {}", userId, e.getMessage());
-            transactionTemplate.executeWithoutResult(status ->
-                    aiCardTaskRepository.findById(taskDbId[0]).ifPresent(AiCardTask::fail));
-            sseEmitterService.sendFailed(userId, "AI 서버 요청에 실패했습니다.");
+            failTask(userId, taskDbId[0], "AI 서버 요청에 실패했습니다.");
             return;
         }
 
@@ -100,9 +98,7 @@ public class AiCardGenerationService {
     private void poll(Integer userId, Integer taskDbId, String aiTaskId, long deadline) {
         if (System.currentTimeMillis() > deadline) {
             log.warn("User {} AI 명함 생성 시간 초과", userId);
-            transactionTemplate.executeWithoutResult(status ->
-                    aiCardTaskRepository.findById(taskDbId).ifPresent(AiCardTask::fail));
-            sseEmitterService.sendFailed(userId, "생성 시간이 초과되었습니다.");
+            failTask(userId, taskDbId, "생성 시간이 초과되었습니다.");
             return;
         }
 
@@ -112,26 +108,29 @@ public class AiCardGenerationService {
             if ("completed".equals(statusResponse.status())) {
                 Optional<AiCardGenerateResponse> result = aiClient.getCardTaskResult(aiTaskId);
                 result.ifPresent(res -> handleCompleted(userId, taskDbId, res));
-                if (result.isEmpty()) {
-                    scheduler.schedule(() -> poll(userId, taskDbId, aiTaskId, deadline),
-                            properties.getCard().getPollIntervalSeconds(), TimeUnit.SECONDS);
-                }
+                if (result.isEmpty()) schedulePoll(userId, taskDbId, aiTaskId, deadline);
             } else if ("failed".equals(statusResponse.status())) {
                 log.warn("User {} AI 명함 생성 실패", userId);
-                transactionTemplate.executeWithoutResult(status ->
-                        aiCardTaskRepository.findById(taskDbId).ifPresent(AiCardTask::fail));
-                sseEmitterService.sendFailed(userId, "이미지 생성에 실패했습니다.");
+                failTask(userId, taskDbId, "이미지 생성에 실패했습니다.");
             } else {
                 sseEmitterService.sendProgress(userId, statusResponse.status(), statusResponse.progress());
-                scheduler.schedule(() -> poll(userId, taskDbId, aiTaskId, deadline),
-                        properties.getCard().getPollIntervalSeconds(), TimeUnit.SECONDS);
+                schedulePoll(userId, taskDbId, aiTaskId, deadline);
             }
         } catch (Exception e) {
             log.error("User {} polling 오류: {}", userId, e.getMessage());
-            transactionTemplate.executeWithoutResult(status ->
-                    aiCardTaskRepository.findById(taskDbId).ifPresent(AiCardTask::fail));
-            sseEmitterService.sendFailed(userId, "이미지 생성 중 오류가 발생했습니다.");
+            failTask(userId, taskDbId, "이미지 생성 중 오류가 발생했습니다.");
         }
+    }
+
+    private void failTask(Integer userId, Integer taskDbId, String message) {
+        transactionTemplate.executeWithoutResult(status ->
+                aiCardTaskRepository.findById(taskDbId).ifPresent(AiCardTask::fail));
+        sseEmitterService.sendFailed(userId, message);
+    }
+
+    private void schedulePoll(Integer userId, Integer taskDbId, String aiTaskId, long deadline) {
+        scheduler.schedule(() -> poll(userId, taskDbId, aiTaskId, deadline),
+                properties.getCard().getPollIntervalSeconds(), TimeUnit.SECONDS);
     }
 
     private void handleCompleted(Integer userId, Integer taskDbId, AiCardGenerateResponse res) {
@@ -142,9 +141,7 @@ public class AiCardGenerationService {
             s3Service.uploadBytes(tempKey, imageBytes, "image/png");
         } catch (Exception e) {
             log.error("User {} S3 업로드 실패: {}", userId, e.getMessage());
-            transactionTemplate.executeWithoutResult(status ->
-                    aiCardTaskRepository.findById(taskDbId).ifPresent(AiCardTask::fail));
-            sseEmitterService.sendFailed(userId, "이미지 저장에 실패했습니다.");
+            failTask(userId, taskDbId, "이미지 저장에 실패했습니다.");
             return;
         }
 

--- a/src/main/java/com/caro/bizkit/domain/ai/service/SseEmitterService.java
+++ b/src/main/java/com/caro/bizkit/domain/ai/service/SseEmitterService.java
@@ -7,16 +7,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.connection.Message;
-import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.listener.ChannelTopic;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -26,20 +26,27 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class SseEmitterService {
 
     private static final long SSE_TIMEOUT = 220_000L;
-    private static final String CHANNEL_PREFIX = "sse:ai-card:";
+    private static final String SSE_CHANNEL = "sse:notifications";
 
     private final ConcurrentHashMap<Integer, SseEmitter> emitterMap = new ConcurrentHashMap<>();
     private final StringRedisTemplate redisTemplate;
-    private final RedisMessageListenerContainer listenerContainer;
     private final AiCardTaskRepository aiCardTaskRepository;
     private final ObjectMapper objectMapper;
 
     public SseEmitter connect(Integer userId) {
+        Optional<AiCardTask> latestTask = aiCardTaskRepository.findTopByUser_IdOrderByCreatedAtDesc(userId);
+        if (latestTask.isPresent()) {
+            AiCardTask task = latestTask.get();
+            if (task.getStatus() == AiAnalysisStatus.FAILED && isWithinOneSecond(task.getUpdatedAt())) {
+                return immediateEmitter("failed", Map.of("event", "failed", "error", "이미지 생성에 실패했습니다."));
+            }
+            if (task.getStatus() == AiAnalysisStatus.COMPLETED && isWithinOneSecond(task.getUpdatedAt())) {
+                return immediateEmitter("completed", Map.of("event", "completed", "image_url", task.getResultImageUrl()));
+            }
+        }
+
         SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);
         AtomicBoolean cleaned = new AtomicBoolean(false);
-        String channel = CHANNEL_PREFIX + userId;
-
-        MessageListener listener = (message, pattern) -> handleRedisMessage(userId, message);
 
         emitter.onTimeout(() -> {
             try {
@@ -51,12 +58,10 @@ public class SseEmitterService {
         if (existing != null) {
             existing.complete();
         }
-        listenerContainer.addMessageListener(listener, new ChannelTopic(channel));
 
         emitter.onCompletion(() -> {
             if (cleaned.compareAndSet(false, true)) {
                 emitterMap.remove(userId, emitter);
-                listenerContainer.removeMessageListener(listener);
             }
         });
 
@@ -81,36 +86,57 @@ public class SseEmitterService {
         publish(userId, Map.of("event", "failed", "error", error));
     }
 
-    private void publish(Integer userId, Map<String, String> data) {
+    public void handleSseMessage(String message, String channel) {
         try {
-            String json = objectMapper.writeValueAsString(data);
-            redisTemplate.convertAndSend(CHANNEL_PREFIX + userId, json);
-        } catch (JsonProcessingException e) {
-            log.error("SSE 이벤트 직렬화 실패: {}", e.getMessage());
-        }
-    }
-
-    private void handleRedisMessage(Integer userId, Message message) {
-        log.info("[SSE] Redis 메시지 수신 userId={}, body={}", userId, new String(message.getBody()));
-        SseEmitter emitter = emitterMap.get(userId);
-        if (emitter == null) {
-            log.warn("[SSE] emitter 없음 userId={} — 메시지 무시", userId);
-            return;
-        }
-
-        try {
-            Map<?, ?> data = objectMapper.readValue(message.getBody(), Map.class);
+            Map<String, Object> data = objectMapper.readValue(message, Map.class);
+            Integer userId = Integer.valueOf((String) data.get("userId"));
             String event = (String) data.get("event");
+
+            SseEmitter emitter = emitterMap.get(userId);
+            if (emitter == null) {
+                log.warn("[SSE] emitter 없음 userId={} — 메시지 무시", userId);
+                return;
+            }
+
+            Map<String, Object> payload = new HashMap<>(data);
+            payload.remove("userId");
+
             log.info("[SSE] 이벤트 전송 시작 userId={}, event={}", userId, event);
-            emitter.send(SseEmitter.event().name(event).data(data));
+            emitter.send(SseEmitter.event().name(event).data(payload));
             log.info("[SSE] 이벤트 전송 완료 userId={}, event={}", userId, event);
+
             if ("completed".equals(event) || "failed".equals(event)) {
                 emitter.complete();
                 log.info("[SSE] emitter complete userId={}", userId);
             }
         } catch (Exception e) {
-            log.error("[SSE] 메시지 전송 실패 userId={}: {} ({})", userId, e.getMessage(), e.getClass().getSimpleName());
+            log.error("[SSE] 메시지 처리 실패: {} ({})", e.getMessage(), e.getClass().getSimpleName());
+        }
+    }
+
+    private void publish(Integer userId, Map<String, String> data) {
+        try {
+            Map<String, String> payload = new HashMap<>(data);
+            payload.put("userId", String.valueOf(userId));
+            String json = objectMapper.writeValueAsString(payload);
+            redisTemplate.convertAndSend(SSE_CHANNEL, json);
+        } catch (JsonProcessingException e) {
+            log.error("SSE 이벤트 직렬화 실패: {}", e.getMessage());
+        }
+    }
+
+    private boolean isWithinOneSecond(LocalDateTime time) {
+        return time != null && ChronoUnit.MILLIS.between(time, LocalDateTime.now()) <= 1000;
+    }
+
+    private SseEmitter immediateEmitter(String event, Map<String, String> data) {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);
+        try {
+            emitter.send(SseEmitter.event().name(event).data(data));
+            emitter.complete();
+        } catch (IOException e) {
             emitter.completeWithError(e);
         }
+        return emitter;
     }
 }

--- a/src/main/java/com/caro/bizkit/domain/chat/config/RedisPubSubConfig.java
+++ b/src/main/java/com/caro/bizkit/domain/chat/config/RedisPubSubConfig.java
@@ -1,5 +1,6 @@
 package com.caro.bizkit.domain.chat.config;
 
+import com.caro.bizkit.domain.ai.service.SseEmitterService;
 import com.caro.bizkit.domain.chat.service.ChatRedisSubscriber;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,6 +23,11 @@ public class RedisPubSubConfig {
     }
 
     @Bean
+    public ChannelTopic sseNotificationTopic() {
+        return new ChannelTopic("sse:notifications");
+    }
+
+    @Bean
     public MessageListenerAdapter chatMessageListenerAdapter(ChatRedisSubscriber subscriber) {
         return new MessageListenerAdapter(subscriber, "onMessage");
     }
@@ -32,17 +38,25 @@ public class RedisPubSubConfig {
     }
 
     @Bean
+    public MessageListenerAdapter sseNotificationListenerAdapter(SseEmitterService sseEmitterService) {
+        return new MessageListenerAdapter(sseEmitterService, "handleSseMessage");
+    }
+
+    @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory connectionFactory,
             MessageListenerAdapter chatMessageListenerAdapter,
             ChannelTopic chatMessageTopic,
             MessageListenerAdapter chatReadListenerAdapter,
-            ChannelTopic chatReadTopic
+            ChannelTopic chatReadTopic,
+            MessageListenerAdapter sseNotificationListenerAdapter,
+            ChannelTopic sseNotificationTopic
     ) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
         container.addMessageListener(chatMessageListenerAdapter, chatMessageTopic);
         container.addMessageListener(chatReadListenerAdapter, chatReadTopic);
+        container.addMessageListener(sseNotificationListenerAdapter, sseNotificationTopic);
         return container;
     }
 }


### PR DESCRIPTION
**Title**
refactor: Redis 동적 구독을 고정 채널로 전환 및 edge case 처리 추가

**Body**
#### 요약
- SSE per-user 동적 구독(sse:ai-card:{userId}) → 단일 고정 채널(sse:notifications)로 변경
- addMessageListener 비동기 타이밍 문제 및 listener 누수 위험 제거
- connect() 진입 시 COMPLETED/FAILED 태스크(1초 이내) 즉시 응답 edge case 추가
- AiCardGenerationService failTask/schedulePoll 헬퍼 추출로 중복 제거


close #178 
