### PR TITLE
fix: soft_delete된 entity들을 조회가능한 현상 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.apache.kafka:kafka-streams'
     implementation platform("software.amazon.awssdk:bom:2.27.21")
     implementation "software.amazon.awssdk:s3"
     implementation 'org.springframework.kafka:spring-kafka'
@@ -55,7 +54,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.batch:spring-batch-test'
-    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/com/caro/bizkit/common/config/CacheConfig.java
+++ b/src/main/java/com/caro/bizkit/common/config/CacheConfig.java
@@ -28,17 +28,6 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableCaching
 public class CacheConfig implements CachingConfigurer {
 
-    /**
-     * Redis CacheManager — 분산 캐시 (UserPrincipal)
-     *
-     * GenericJackson2JsonRedisSerializer + default typing ObjectMapper 조합:
-     * - JSON에 @class 타입 정보 포함 → 역직렬화 시 LinkedHashMap 캐스팅 오류 방지
-     * - Spring Boot ObjectMapper를 복사해 ParameterNamesModule 등 기존 설정 유지
-     * - activateDefaultTyping(NON_FINAL) → 비-final 타입에 @class 추가
-     * - record(final) 등 캐싱 대상 클래스는 @JsonTypeInfo(CLASS) 어노테이션으로 @class 삽입
-     * - allowIfSubType("com.caro.bizkit.") → @class 실제 값이 자사 패키지일 때만 허용 (보안 화이트리스트)
-     * - @class 필드 포함 → 패키지 경로 변경 시 역직렬화 실패 주의
-     */
     @Bean("redisCacheManager")
     @Primary
     public CacheManager redisCacheManager(RedisConnectionFactory cf, ObjectMapper objectMapper) {

--- a/src/main/java/com/caro/bizkit/domain/userdetail/activity/repository/ActivityRepository.java
+++ b/src/main/java/com/caro/bizkit/domain/userdetail/activity/repository/ActivityRepository.java
@@ -5,5 +5,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ActivityRepository extends JpaRepository<Activity, Integer> {
+    List<Activity> findAllByUserId(Integer userId);
     List<Activity> findAllByUserIdAndDeletedAtIsNull(Integer userId);
 }

--- a/src/main/java/com/caro/bizkit/domain/userdetail/activity/repository/ActivityRepository.java
+++ b/src/main/java/com/caro/bizkit/domain/userdetail/activity/repository/ActivityRepository.java
@@ -5,5 +5,5 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ActivityRepository extends JpaRepository<Activity, Integer> {
-    List<Activity> findAllByUserId(Integer userId);
+    List<Activity> findAllByUserIdAndDeletedAtIsNull(Integer userId);
 }

--- a/src/main/java/com/caro/bizkit/domain/userdetail/activity/service/ActivityService.java
+++ b/src/main/java/com/caro/bizkit/domain/userdetail/activity/service/ActivityService.java
@@ -30,7 +30,7 @@ public class ActivityService {
 
     @Transactional(readOnly = true)
     public List<ActivityResponse> getMyActivities(UserPrincipal principal) {
-        return activityRepository.findAllByUserId(principal.id()).stream()
+        return activityRepository.findAllByUserIdAndDeletedAtIsNull(principal.id()).stream()
                 .map(ActivityResponse::from)
                 .toList();
     }
@@ -38,7 +38,7 @@ public class ActivityService {
     @Transactional(readOnly = true)
     public List<ActivityResponse> getActivitiesByUserId(UserPrincipal principal, Integer userId) {
         cardCollectionValidator.validateAccess(principal.id(), userId);
-        return activityRepository.findAllByUserId(userId).stream()
+        return activityRepository.findAllByUserIdAndDeletedAtIsNull(userId).stream()
                 .map(ActivityResponse::from)
                 .toList();
     }

--- a/src/main/java/com/caro/bizkit/domain/userdetail/link/repository/LinkRepository.java
+++ b/src/main/java/com/caro/bizkit/domain/userdetail/link/repository/LinkRepository.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LinkRepository extends JpaRepository<Link, Integer> {
-    List<Link> findAllByUserId(Integer userId);
+    List<Link> findAllByUserIdAndDeletedAtIsNull(Integer userId);
 
     @org.springframework.data.jpa.repository.Query(
             "SELECT l FROM Link l WHERE l.user.id = :userId AND l.link LIKE %:keyword%"

--- a/src/main/java/com/caro/bizkit/domain/userdetail/link/repository/LinkRepository.java
+++ b/src/main/java/com/caro/bizkit/domain/userdetail/link/repository/LinkRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LinkRepository extends JpaRepository<Link, Integer> {
+    List<Link> findAllByUserId(Integer userId);
     List<Link> findAllByUserIdAndDeletedAtIsNull(Integer userId);
 
     @org.springframework.data.jpa.repository.Query(

--- a/src/main/java/com/caro/bizkit/domain/userdetail/link/service/LinkService.java
+++ b/src/main/java/com/caro/bizkit/domain/userdetail/link/service/LinkService.java
@@ -31,7 +31,7 @@ public class LinkService {
 
     @Transactional(readOnly = true)
     public List<LinkResponse> getMyLinks(UserPrincipal principal) {
-        return linkRepository.findAllByUserId(principal.id()).stream()
+        return linkRepository.findAllByUserIdAndDeletedAtIsNull(principal.id()).stream()
                 .map(LinkResponse::from)
                 .toList();
     }
@@ -39,7 +39,7 @@ public class LinkService {
     @Transactional(readOnly = true)
     public List<LinkResponse> getLinksByUserId(UserPrincipal principal, Integer userId) {
         cardCollectionValidator.validateAccess(principal.id(), userId);
-        return linkRepository.findAllByUserId(userId).stream()
+        return linkRepository.findAllByUserIdAndDeletedAtIsNull(userId).stream()
                 .map(LinkResponse::from)
                 .toList();
     }

--- a/src/main/java/com/caro/bizkit/domain/userdetail/project/repository/ProjectRepository.java
+++ b/src/main/java/com/caro/bizkit/domain/userdetail/project/repository/ProjectRepository.java
@@ -6,6 +6,6 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectRepository extends JpaRepository<Project, Integer> {
-    List<Project> findAllByUserId(Integer userId);
-    Optional<Project> findByIdAndUserId(Integer id, Integer userId);
+    List<Project> findAllByUserIdAndDeletedAtIsNull(Integer userId);
+    Optional<Project> findByIdAndUserIdAndDeletedAtIsNull(Integer id, Integer userId);
 }

--- a/src/main/java/com/caro/bizkit/domain/userdetail/project/repository/ProjectRepository.java
+++ b/src/main/java/com/caro/bizkit/domain/userdetail/project/repository/ProjectRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectRepository extends JpaRepository<Project, Integer> {
+    List<Project> findAllByUserId(Integer userId);
     List<Project> findAllByUserIdAndDeletedAtIsNull(Integer userId);
+    Optional<Project> findByIdAndUserId(Integer id, Integer userId);
     Optional<Project> findByIdAndUserIdAndDeletedAtIsNull(Integer id, Integer userId);
 }

--- a/src/main/java/com/caro/bizkit/domain/userdetail/project/service/ProjectService.java
+++ b/src/main/java/com/caro/bizkit/domain/userdetail/project/service/ProjectService.java
@@ -31,7 +31,7 @@ public class ProjectService {
 
     @Transactional(readOnly = true)
     public List<ProjectResponse> getMyProjects(UserPrincipal principal) {
-        return projectRepository.findAllByUserId(principal.id()).stream()
+        return projectRepository.findAllByUserIdAndDeletedAtIsNull(principal.id()).stream()
                 .map(ProjectResponse::from)
                 .toList();
     }
@@ -39,7 +39,7 @@ public class ProjectService {
     @Transactional(readOnly = true)
     public List<ProjectResponse> getProjectsByUserId(UserPrincipal principal, Integer userId) {
         cardCollectionValidator.validateAccess(principal.id(), userId);
-        return projectRepository.findAllByUserId(userId).stream()
+        return projectRepository.findAllByUserIdAndDeletedAtIsNull(userId).stream()
                 .map(ProjectResponse::from)
                 .toList();
     }


### PR DESCRIPTION
**Title**
fix: soft_delete된 entity들을 조회가능한 현상 수정

**Body**
- findallbyuserId에 deletedatisnull 추가
- rabbitMQ 사용 결정에 따라 kafka 의존성 제거
- findall을 사용하는 메서드들이 있어 다시 생성

